### PR TITLE
Add speed value to progress

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -489,7 +489,7 @@ fn main() {
             let runtime = start_time.elapsed();
             let keys_per_second = (attempts as f64)
                 // simplify to .as_millis() when available
-                / (runtime.as_secs() as f64 + runtime.subsec_millis() as f64 * 1e-3);
+                / (runtime.as_secs() as f64 + runtime.subsec_millis() as f64 / 1000.0);
             eprint!(
                 "\rTried {} keys (~{:.2}%; {:.1} keys/s)",
                 attempts, estimated_percent, keys_per_second,

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ extern crate ocl;
 extern crate ocl_core;
 
 mod matcher;
-use matcher::{Matcher, GenerateKeyType};
+use matcher::{GenerateKeyType, Matcher};
 
 #[cfg(feature = "gpu")]
 mod gpu;
@@ -491,7 +491,7 @@ fn main() {
             let keys_per_second = (attempts as f64) / runtime;
             eprint!(
                 "\rTried {} keys (~{:.2}%; {:.1} keys/s)",
-                attempts, estimated_percent, keys_per_second
+                attempts, estimated_percent, keys_per_second,
             );
             thread::sleep(Duration::from_millis(250));
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -486,9 +486,9 @@ fn main() {
             let attempts = attempts.load(atomic::Ordering::Relaxed);
             let estimated_percent =
                 100. * (attempts as f64) / estimated_attempts.to_f64().unwrap_or(f64::INFINITY);
-            let runtime = start_time.elapsed().as_secs() as f64
-                + start_time.elapsed().subsec_nanos() as f64 * 1e-9;
-            let keys_per_second = (attempts as f64) / runtime;
+            let runtime = start_time.elapsed();
+            let keys_per_second = (attempts as f64)
+                / (runtime.as_secs() as f64 + runtime.subsec_nanos() as f64 * 1e-9);
             eprint!(
                 "\rTried {} keys (~{:.2}%; {:.1} keys/s)",
                 attempts, estimated_percent, keys_per_second,

--- a/src/main.rs
+++ b/src/main.rs
@@ -462,7 +462,7 @@ fn main() {
                 if output_progress {
                     params
                         .attempts
-                        .fetch_add(gpu_threads - 1, atomic::Ordering::Relaxed);
+                        .fetch_add(gpu_threads, atomic::Ordering::Relaxed);
                 }
                 if !found {
                     continue;

--- a/src/main.rs
+++ b/src/main.rs
@@ -488,7 +488,8 @@ fn main() {
                 100. * (attempts as f64) / estimated_attempts.to_f64().unwrap_or(f64::INFINITY);
             let runtime = start_time.elapsed();
             let keys_per_second = (attempts as f64)
-                / (runtime.as_secs() as f64 + runtime.subsec_nanos() as f64 * 1e-9);
+                // simplify to .as_millis() when available
+                / (runtime.as_secs() as f64 + runtime.subsec_millis() as f64 * 1e-3);
             eprint!(
                 "\rTried {} keys (~{:.2}%; {:.1} keys/s)",
                 attempts, estimated_percent, keys_per_second,


### PR DESCRIPTION
Shows the average speed in the progress allowing some benchmarking before the address is found:

```
Estimated attempts needed: 1048576
Tried 420178 keys (~40.07%; 2549.0 keys/s)
```

The speed value matches the `time` tool:

```
$ time ./target/debug/nano-vanity .simo
Estimated attempts needed: 1048576
Tried 1892494 keys (~180.48%; 2193.5 keys/s)
Found matching account!
Private Key: 08EE7A2C4207670F261BE5B7FDD2FFAAC4D831D1ECFF1EBB946C6A00C8BCEAE9
Account:     xrb_3simo47gd8b33q8iwr6u1i5r1mcgjrcgpzx6bistwww4m6d5wf68dxkxjicq
./target/debug/nano-vanity .simo  2104,48s user 14,30s system 245% cpu 14:22,91 total
```

`14:22,91 total` is `14*60+23 = 863` seconds. `1892494 keys / 863 s = 2192,9 / s`, while `time` includes starting and ending the process.