### PR TITLE
Fix number of elements in memset replacement loop 

### DIFF
--- a/merge-kernel.py
+++ b/merge-kernel.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+# Merges OpenCL source files into a single file for compilation
+# equivalent to what gpu.rs does.
+#
+# Example usages:
+#   ./merge-kernel.py > kernel.cl
+#   ./merge-kernel.py | cat -n
+
+import sys
+
+files = [
+    "blake2b.cl",
+    "curve25519-constants.cl",
+    "curve25519-constants2.cl",
+    "curve25519.cl",
+    "entry.cl"
+]
+
+for f_name in files:
+    with open("src/opencl/" + f_name, "r") as f:
+        for line in f:
+            sys.stdout.write(line)

--- a/src/opencl/curve25519.cl
+++ b/src/opencl/curve25519.cl
@@ -1496,6 +1496,7 @@ ge25519_scalarmult_base_choose_niels(ge25519_niels *t, uint32_t pos, signed char
 
 /* computes [s]basepoint */
 // modified to remove basepoint table argument
+// and to work around the missing memset function
 static void
 ge25519_scalarmult_base_niels(ge25519 *r, const bignum256modm s) {
 	signed char b[64];
@@ -1507,8 +1508,9 @@ ge25519_scalarmult_base_niels(ge25519 *r, const bignum256modm s) {
 	ge25519_scalarmult_base_choose_niels(&t, 0, b[1]);
 	curve25519_sub_reduce(r->x, t.xaddy, t.ysubx);
 	curve25519_add_reduce(r->y, t.xaddy, t.ysubx);
-	//memset(r->z, 0, sizeof(bignum25519));
-	for (size_t n = 0; n < sizeof(bignum25519); n++) r->z[n] = 0;
+	// Original code: memset(r->z, 0, sizeof(bignum25519));
+	// r->z is a bignum25519, i.e. a 10 element array
+	for (size_t n = 0; n < 10; n++) r->z[n] = 0;
 	curve25519_copy(r->t, t.t2d);
 	r->z[0] = 2;	
 	for (i = 3; i < 64; i += 2) {


### PR DESCRIPTION
While [trying to compile](https://community.amd.com/thread/234809) this code (a fork of it but results are the same) on a modern AMD GPU, user dipak discovered that there is a out of bound array access caused by using `sizeof(bignum25519)` (i.e. the number of bytes) as the number of elements in the array.

merge-kernel.py was added to be able to better analyze the kernel and compile it without all the rust around it.

Unfortunatly the kernel still does not compile usging the rocm opencl compiler (compiler hangs forever when optimization is enabled). But there seems to be no way to get proper error messages from the compiler due to some intermediate compilation language. Is there any chance to find other out of bound memory accesses by code review? Other places you know you modified?