### PR TITLE
Fix build with GPU feature disabled

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,7 @@ impl Gpu {
         _: usize,
         _: usize,
         _: usize,
+        _: Option<usize>,
         _: &PubkeyMatcher,
         _: GenerateKeyType,
     ) -> Result<Gpu, String> {


### PR DESCRIPTION
Before, `cargo build --no-default-features` failed with

```
error[E0061]: this function takes 5 parameters but 6 parameters were supplied
   --> src/main.rs:414:23
    |
48  | /     pub fn new(
49  | |         _: usize,
50  | |         _: usize,
51  | |         _: usize,
...   |
57  | |         process::exit(1);
58  | |     }
    | |_____- defined here
...
414 |           let mut gpu = Gpu::new(
    |  _______________________^
415 | |             gpu_platform,
416 | |             gpu_device,
417 | |             gpu_threads,
...   |
420 | |             gen_key_ty,
421 | |         )
    | |_________^ expected 5 parameters

error: aborting due to previous error

For more information about this error, try `rustc --explain E0061`.
error: Could not compile `nano-vanity`.

To learn more, run the command again with --verbose.
```