### PR TITLE
change tyoe of result to unsigned long

### DIFF
--- a/src/opencl/entry.cl
+++ b/src/opencl/entry.cl
@@ -6,7 +6,7 @@ inline void generate_checksum (uchar checksum[5], const uchar pubkey[32]) {
 	blake2b_final (&state, (__private uchar *) checksum, 5);
 }
 
-__kernel void generate_pubkey (__global uint64_t *result, __global uchar *key_root, __global uchar *pub_req, __global uchar *pub_mask, uchar prefix_len, uchar generate_key_type, __global uchar *public_offset) {
+__kernel void generate_pubkey (__global unsigned long *result, __global uchar *key_root, __global uchar *pub_req, __global uchar *pub_mask, uchar prefix_len, uchar generate_key_type, __global uchar *public_offset) {
 	size_t const thread = get_global_id (0);
 	uchar key[32];
 	for (size_t i = 0; i < 32; i++) {


### PR DESCRIPTION
fix Kernel argument type mismatch error
```
Initializing GPU Advanced Micro Devices, Inc. Ellesmere
thread 'main' panicked at 'called Result::unwrap() on an Err value: 
Kernel argument type mismatch. 
The argument named: 'result' at index: [0] should be a 'uint64_t*' 
(ArgType { base_type: Uint, cardinality: Four, is_ptr: true }).', 
C:\Users\My1.cargo\registry\src\github.com-1ecc6299db9ec823\nano-vanity-0.4.10\src\main.rs:404:10
stack backtrace:
   0:     0x7ff6119e3449 - <unknown>
   1:     0x7ff6119f85db - <unknown>
   2:     0x7ff6119dfee8 - <unknown>
   3:     0x7ff6119e61f4 - <unknown>
   4:     0x7ff6119e5dd8 - <unknown>
   5:     0x7ff6119e6aaf - <unknown>
   6:     0x7ff6119e6615 - <unknown>
   7:     0x7ff6119e3d2f - <unknown>
   8:     0x7ff6119e65c9 - <unknown>
   9:     0x7ff6119f6da0 - <unknown>
  10:     0x7ff6119f6bd3 - <unknown>
  11:     0x7ff61193437f - <unknown>
  12:     0x7ff61191fe76 - <unknown>
  13:     0x7ff61193c09c - <unknown>
  14:     0x7ff6119e6cb3 - <unknown>
  15:     0x7ff611935b37 - <unknown>
  16:     0x7ff6119ff50c - <unknown>
  17:     0x7ff809d713f2 - BaseThreadInitThunk
  18:     0x7ff80c4154f4 - RtlUserThreadStart
```