### PR TITLE
Fix for OpenCL 2.0

### DIFF
--- a/src/opencl/blake2b.cl
+++ b/src/opencl/blake2b.cl
@@ -259,7 +259,7 @@ static int blake2b_update( __private blake2b_state *S, const uchar *in, ulong in
   }
   return 0;
 }
-/* Is this correct? */
+
 static int blake2b_final( __private blake2b_state *S, uchar *out, uchar outlen )
 {
   uchar buffer[BLAKE2B_OUTBYTES];

--- a/src/opencl/blake2b.cl
+++ b/src/opencl/blake2b.cl
@@ -292,21 +292,3 @@ static void ucharcpyglb (uchar * dst, __global uchar const * src, size_t count)
 		++src;
 	}
 }
-	
-__kernel void nano_work (__global ulong const * attempt, __global ulong * result_a, __global uchar const * item_a, __global ulong const * difficulty_a)
-{
-	int const thread = get_global_id (0);
-	uchar item_l [32];
-	ucharcpyglb (item_l, item_a, 32);
-	ulong attempt_l = *attempt + thread;
-	blake2b_state state;
-	blake2b_init (&state, sizeof (ulong));
-	blake2b_update (&state, (uchar *) &attempt_l, sizeof (ulong));
-	blake2b_update (&state, item_l, 32);
-	ulong result;
-	blake2b_final (&state, (uchar *) &result, sizeof (result));
-	if (result >= *difficulty_a)
-	{
-		*result_a = attempt_l;
-	}
-}

--- a/src/opencl/blake2b.cl
+++ b/src/opencl/blake2b.cl
@@ -1,3 +1,5 @@
+// Taken from Nano's openclwork.cpp
+
 enum blake2b_constant
 {
 	BLAKE2B_BLOCKBYTES = 128,


### PR DESCRIPTION
The default address space changed from private to generic in OpenCL 2.0, causing #40. This merges some OpenCL optimizations from Nano, and fixes the issue.