### PR TITLE
Estimated percentage following statistic logaritmic curve

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,7 @@ fn check_solution(params: &ThreadParams, key_material: [u8; 32]) -> bool {
             public_key,
             params.simple_output,
         );
+        params.attempts.store(0, atomic::Ordering::Relaxed);
         if params.limit != 0
             && params.found_n.fetch_add(1, atomic::Ordering::Relaxed) + 1 >= params.limit
         {
@@ -423,7 +424,6 @@ fn main() {
                         hex::encode_upper(&found_private_key),
                     );
                 }
-                params.attempts.store(0, atomic::Ordering::Relaxed);
                 for byte in &mut found_private_key {
                     *byte = 0;
                 }

--- a/src/pubkey_matcher.rs
+++ b/src/pubkey_matcher.rs
@@ -2,7 +2,6 @@ use std::cmp;
 
 use blake2::VarBlake2b;
 use digest::{Update, VariableOutput};
-use num_bigint::BigInt;
 
 #[derive(Clone)]
 pub struct PubkeyMatcher {
@@ -68,11 +67,11 @@ impl PubkeyMatcher {
         true
     }
 
-    pub fn estimated_attempts(&self) -> BigInt {
+    pub fn finding_chance(&self) -> f64 {
         let mut bits_in_mask = 0;
         for byte in &self.mask {
-            bits_in_mask += byte.count_ones() as usize;
+            bits_in_mask += byte.count_ones() as i32;
         }
-        BigInt::from(1) << bits_in_mask
+        2.0_f64.powi(-bits_in_mask)
     }
 }


### PR DESCRIPTION
Code modified so the printing percentage represent the odds of at least one successful outcome, given the current number of tries. More information at: https://www.statology.org/probability-of-at-least-one-success/

To keep the correct number of tries per second, I believe the best approach is to restart the variable "start_time" (main.rs 434), but this knowledge is beyond my capabilities in Rust. Does it need to be passed thru "params" to threads?

This can close issue  #44 