### PR TITLE
Fix opencl for newer nvidia drivers

### DIFF
--- a/src/opencl/curve25519.cl
+++ b/src/opencl/curve25519.cl
@@ -472,7 +472,7 @@ __constant uint32_t reduce_mask_26 = (1 << 26) - 1;
 
 /* out = in */
 __inline void
-curve25519_copy(bignum25519 out, const bignum25519 in) {
+curve25519_copy(__generic bignum25519 out, const __generic bignum25519 in) {
 	out[0] = in[0];
 	out[1] = in[1];
 	out[2] = in[2];
@@ -487,7 +487,7 @@ curve25519_copy(bignum25519 out, const bignum25519 in) {
 
 /* out = a + b */
 __inline void
-curve25519_add(bignum25519 out, const bignum25519 a, const bignum25519 b) {
+curve25519_add(__generic bignum25519 out, const __generic bignum25519 a, const __generic bignum25519 b) {
 	out[0] = a[0] + b[0];
 	out[1] = a[1] + b[1];
 	out[2] = a[2] + b[2];
@@ -501,7 +501,7 @@ curve25519_add(bignum25519 out, const bignum25519 a, const bignum25519 b) {
 }
 
 __inline void 
-curve25519_add_after_basic(bignum25519 out, const bignum25519 a, const bignum25519 b) {
+curve25519_add_after_basic(__generic bignum25519 out, const __generic bignum25519 a, const __generic bignum25519 b) {
 	uint32_t c;
 	out[0] = a[0] + b[0]    ; c = (out[0] >> 26); out[0] &= reduce_mask_26;
 	out[1] = a[1] + b[1] + c; c = (out[1] >> 25); out[1] &= reduce_mask_25;
@@ -517,7 +517,7 @@ curve25519_add_after_basic(bignum25519 out, const bignum25519 a, const bignum255
 }
 
 __inline void
-curve25519_add_reduce(bignum25519 out, const bignum25519 a, const bignum25519 b) {
+curve25519_add_reduce(__generic bignum25519 out, const __generic bignum25519 a, const __generic bignum25519 b) {
 	uint32_t c;
 	out[0] = a[0] + b[0]    ; c = (out[0] >> 26); out[0] &= reduce_mask_26;
 	out[1] = a[1] + b[1] + c; c = (out[1] >> 25); out[1] &= reduce_mask_25;
@@ -542,7 +542,7 @@ __constant uint32_t fourP2468   = 0x0ffffffc;
 
 /* out = a - b */
 __inline void
-curve25519_sub(bignum25519 out, const bignum25519 a, const bignum25519 b) {
+curve25519_sub(__generic bignum25519 out, const __generic bignum25519 a, const __generic bignum25519 b) {
 	uint32_t c;
 	out[0] = twoP0     + a[0] - b[0]    ; c = (out[0] >> 26); out[0] &= reduce_mask_26;
 	out[1] = twoP13579 + a[1] - b[1] + c; c = (out[1] >> 25); out[1] &= reduce_mask_25;
@@ -558,7 +558,7 @@ curve25519_sub(bignum25519 out, const bignum25519 a, const bignum25519 b) {
 
 /* out = a - b, where a is the result of a basic op (add,sub) */
 __inline void
-curve25519_sub_after_basic(bignum25519 out, const bignum25519 a, const bignum25519 b) {
+curve25519_sub_after_basic(__generic bignum25519 out, const __generic bignum25519 a, const __generic bignum25519 b) {
 	uint32_t c;
 	out[0] = fourP0     + a[0] - b[0]    ; c = (out[0] >> 26); out[0] &= reduce_mask_26;
 	out[1] = fourP13579 + a[1] - b[1] + c; c = (out[1] >> 25); out[1] &= reduce_mask_25;
@@ -574,7 +574,7 @@ curve25519_sub_after_basic(bignum25519 out, const bignum25519 a, const bignum255
 }
 
 __inline void
-curve25519_sub_reduce(bignum25519 out, const bignum25519 a, const bignum25519 b) {
+curve25519_sub_reduce(__generic bignum25519 out, const __generic bignum25519 a, const __generic bignum25519 b) {
 	uint32_t c;
 	out[0] = fourP0     + a[0] - b[0]    ; c = (out[0] >> 26); out[0] &= reduce_mask_26;
 	out[1] = fourP13579 + a[1] - b[1] + c; c = (out[1] >> 25); out[1] &= reduce_mask_25;
@@ -591,7 +591,7 @@ curve25519_sub_reduce(bignum25519 out, const bignum25519 a, const bignum25519 b)
 
 /* out = -a */
 __inline void
-curve25519_neg(bignum25519 out, const bignum25519 a) {
+curve25519_neg(__generic bignum25519 out, const __generic bignum25519 a) {
 	uint32_t c;
 	out[0] = twoP0     - a[0]    ; c = (out[0] >> 26); out[0] &= reduce_mask_26;
 	out[1] = twoP13579 - a[1] + c; c = (out[1] >> 25); out[1] &= reduce_mask_25;
@@ -609,7 +609,7 @@ curve25519_neg(bignum25519 out, const bignum25519 a) {
 /* out = a * b */
 #define curve25519_mul_noinline curve25519_mul
 static void
-curve25519_mul(bignum25519 out, const bignum25519 a, const bignum25519 b) {
+curve25519_mul(__generic bignum25519 out, const __generic bignum25519 a, const __generic bignum25519 b) {
 	uint32_t r0,r1,r2,r3,r4,r5,r6,r7,r8,r9;
 	uint32_t s0,s1,s2,s3,s4,s5,s6,s7,s8,s9;
 	uint64_t m0,m1,m2,m3,m4,m5,m6,m7,m8,m9,c;
@@ -706,7 +706,7 @@ curve25519_mul(bignum25519 out, const bignum25519 a, const bignum25519 b) {
 }
 
 static void
-curve25519_mul_const(bignum25519 out, const bignum25519 a, constant uint32_t *b) {
+curve25519_mul_const(__generic bignum25519 out, const __generic bignum25519 a, constant uint32_t *b) {
 	uint32_t r0,r1,r2,r3,r4,r5,r6,r7,r8,r9;
 	uint32_t s0,s1,s2,s3,s4,s5,s6,s7,s8,s9;
 	uint64_t m0,m1,m2,m3,m4,m5,m6,m7,m8,m9,c;
@@ -804,7 +804,7 @@ curve25519_mul_const(bignum25519 out, const bignum25519 a, constant uint32_t *b)
 
 /* out = in*in */
 static void
-curve25519_square(bignum25519 out, const bignum25519 in) {
+curve25519_square(__generic bignum25519 out, const __generic bignum25519 in) {
 	uint32_t r0,r1,r2,r3,r4,r5,r6,r7,r8,r9;
 	uint32_t d6,d7,d8,d9;
 	uint64_t m0,m1,m2,m3,m4,m5,m6,m7,m8,m9,c;
@@ -879,7 +879,7 @@ curve25519_square(bignum25519 out, const bignum25519 in) {
 
 /* out = in ^ (2 * count) */
 static void
-curve25519_square_times(bignum25519 out, const bignum25519 in, int count) {
+curve25519_square_times(bignum25519 out, const __generic bignum25519 in, int count) {
 	uint32_t r0,r1,r2,r3,r4,r5,r6,r7,r8,r9;
 	uint32_t d6,d7,d8,d9;
 	uint64_t m0,m1,m2,m3,m4,m5,m6,m7,m8,m9,c;
@@ -955,7 +955,7 @@ curve25519_square_times(bignum25519 out, const bignum25519 in, int count) {
 
 /* Take a little-endian, 32-byte number and expand it into polynomial form */
 static void
-curve25519_expand(bignum25519 out, const unsigned char in[32]) {
+curve25519_expand(__generic bignum25519 out, const unsigned char in[32]) {
 	uint32_t x0,x1,x2,x3,x4,x5,x6,x7;
 
 #if defined(__ENDIAN_LITTLE__)
@@ -1000,7 +1000,7 @@ curve25519_expand(bignum25519 out, const unsigned char in[32]) {
  * little-endian, 32-byte array
  */
 static void
-curve25519_contract(unsigned char out[32], const bignum25519 in) {
+curve25519_contract(unsigned char out[32], const __generic bignum25519 in) {
 	bignum25519 f;
 	curve25519_copy(f, in);
 
@@ -1116,7 +1116,7 @@ curve25519_move_conditional_bytes(uint8_t out[96], constant uint8_t *in, uint32_
 
 /* if (iswap) swap(a, b) */
 __inline void
-curve25519_swap_conditional(bignum25519 a, bignum25519 b, uint32_t iswap) {
+curve25519_swap_conditional(__generic bignum25519 a, __generic bignum25519 b, uint32_t iswap) {
 	const uint32_t swap = (uint32_t)(-(int32_t)iswap);
 	uint32_t x0,x1,x2,x3,x4,x5,x6,x7,x8,x9;
 
@@ -1138,14 +1138,14 @@ curve25519_swap_conditional(bignum25519 a, bignum25519 b, uint32_t iswap) {
 */
 
 __inline void
-ge25519_p1p1_to_partial(ge25519 *r, const ge25519_p1p1 *p) {
+ge25519_p1p1_to_partial(ge25519 *r, const __generic ge25519_p1p1 *p) {
 	curve25519_mul(r->x, p->x, p->t);
 	curve25519_mul(r->y, p->y, p->z);
 	curve25519_mul(r->z, p->z, p->t); 
 }
 
 __inline void
-ge25519_p1p1_to_full(ge25519 *r, const ge25519_p1p1 *p) {
+ge25519_p1p1_to_full(ge25519 *r, const __generic ge25519_p1p1 *p) {
 	curve25519_mul(r->x, p->x, p->t);
 	curve25519_mul(r->y, p->y, p->z);
 	curve25519_mul(r->z, p->z, p->t); 
@@ -1153,7 +1153,7 @@ ge25519_p1p1_to_full(ge25519 *r, const ge25519_p1p1 *p) {
 }
 
 static void
-ge25519_full_to_pniels(ge25519_pniels *p, const ge25519 *r) {
+ge25519_full_to_pniels(ge25519_pniels *p, const __generic ge25519 *r) {
 	curve25519_sub(p->ysubx, r->y, r->x);
 	curve25519_add(p->xaddy, r->y, r->x);
 	curve25519_copy(p->z, r->z);
@@ -1165,7 +1165,7 @@ ge25519_full_to_pniels(ge25519_pniels *p, const ge25519 *r) {
 */
 
 static void
-ge25519_add_p1p1(ge25519_p1p1 *r, const ge25519 *p, const ge25519 *q) {
+ge25519_add_p1p1(ge25519_p1p1 *r, const __generic ge25519 *p, const __generic ge25519 *q) {
 	bignum25519 a,b,c,d,t,u;
 
 	curve25519_sub(a, p->y, p->x);
@@ -1186,7 +1186,7 @@ ge25519_add_p1p1(ge25519_p1p1 *r, const ge25519 *p, const ge25519 *q) {
 
 
 static void
-ge25519_double_p1p1(ge25519_p1p1 *r, const ge25519 *p) {
+ge25519_double_p1p1(ge25519_p1p1 *r, const __generic ge25519 *p) {
 	bignum25519 a,b,c;
 
 	curve25519_square(a, p->x);
@@ -1202,7 +1202,7 @@ ge25519_double_p1p1(ge25519_p1p1 *r, const ge25519 *p) {
 }
 
 static void
-ge25519_nielsadd2_p1p1(ge25519_p1p1 *r, const ge25519 *p, const ge25519_niels *q, unsigned char signbit) {
+ge25519_nielsadd2_p1p1(ge25519_p1p1 *r, const __generic ge25519 *p, const __generic ge25519_niels *q, unsigned char signbit) {
 	const bignum25519 *qb = (const bignum25519 *)q;
 	bignum25519 *rb = (bignum25519 *)r;
 	bignum25519 a,b,c;
@@ -1221,7 +1221,7 @@ ge25519_nielsadd2_p1p1(ge25519_p1p1 *r, const ge25519 *p, const ge25519_niels *q
 }
 
 static void
-ge25519_pnielsadd_p1p1(ge25519_p1p1 *r, const ge25519 *p, const ge25519_pniels *q, unsigned char signbit) {
+ge25519_pnielsadd_p1p1(ge25519_p1p1 *r, const __generic ge25519 *p, const __generic ge25519_pniels *q, unsigned char signbit) {
 	const bignum25519 *qb = (const bignum25519 *)q;
 	bignum25519 *rb = (bignum25519 *)r;
 	bignum25519 a,b,c;
@@ -1241,28 +1241,28 @@ ge25519_pnielsadd_p1p1(ge25519_p1p1 *r, const ge25519 *p, const ge25519_pniels *
 }
 
 static void
-ge25519_double_partial(ge25519 *r, const ge25519 *p) {
+ge25519_double_partial(ge25519 *r, const __generic ge25519 *p) {
 	ge25519_p1p1 t;
 	ge25519_double_p1p1(&t, p);
 	ge25519_p1p1_to_partial(r, &t);
 }
 
 static void
-ge25519_double(ge25519 *r, const ge25519 *p) {
+ge25519_double(ge25519 *r, const __generic ge25519 *p) {
 	ge25519_p1p1 t;
 	ge25519_double_p1p1(&t, p);
 	ge25519_p1p1_to_full(r, &t);
 }
 
 static void
-ge25519_add(ge25519 *r, const ge25519 *p,  const ge25519 *q) {
+ge25519_add(ge25519 *r, const __generic ge25519 *p,  const __generic ge25519 *q) {
 	ge25519_p1p1 t;
 	ge25519_add_p1p1(&t, p, q);
 	ge25519_p1p1_to_full(r, &t);
 }
 
 static void
-ge25519_nielsadd2(ge25519 *r, const ge25519_niels *q) {
+ge25519_nielsadd2(ge25519 *r, const __generic ge25519_niels *q) {
 	bignum25519 a,b,c,e,f,g,h;
 
 	curve25519_sub(a, r->y, r->x);
@@ -1282,7 +1282,7 @@ ge25519_nielsadd2(ge25519 *r, const ge25519_niels *q) {
 }
 
 static void
-ge25519_pnielsadd(ge25519_pniels *r, const ge25519 *p, const ge25519_pniels *q) {
+ge25519_pnielsadd(ge25519_pniels *r, const __generic ge25519 *p, const __generic ge25519_pniels *q) {
 	bignum25519 a,b,c,x,y,z,t;
 
 	curve25519_sub(a, p->y, p->x);
@@ -1311,7 +1311,7 @@ ge25519_pnielsadd(ge25519_pniels *r, const ge25519 *p, const ge25519_pniels *q) 
  * Out: b = 2^250 - 2^0
  */
 static void
-curve25519_pow_two5mtwo0_two250mtwo0(bignum25519 b) {
+curve25519_pow_two5mtwo0_two250mtwo0(__generic bignum25519 b) {
 	bignum25519 ALIGN(16) t0,c;
 
 	/* 2^5  - 2^0 */ /* b */
@@ -1335,7 +1335,7 @@ curve25519_pow_two5mtwo0_two250mtwo0(bignum25519 b) {
  * z^(p - 2) = z(2^255 - 21)
  */
 static void
-curve25519_recip(bignum25519 out, const bignum25519 z) {
+curve25519_recip(__generic bignum25519 out, const __generic bignum25519 z) {
 	bignum25519 ALIGN(16) a,t0,b;
 
 	/* 2 */ curve25519_square_times(a, z, 1); /* a = 2 */
@@ -1353,7 +1353,7 @@ curve25519_recip(bignum25519 out, const bignum25519 z) {
  * z^((p-5)/8) = z^(2^252 - 3)
  */
 static void
-curve25519_pow_two252m3(bignum25519 two252m3, const bignum25519 z) {
+curve25519_pow_two252m3(__generic bignum25519 two252m3, const __generic bignum25519 z) {
 	bignum25519 ALIGN(16) b,c,t0;
 
 	/* 2 */ curve25519_square_times(c, z, 1); /* c = 2 */
@@ -1373,7 +1373,7 @@ curve25519_pow_two252m3(bignum25519 two252m3, const bignum25519 z) {
 */
 
 static void
-ge25519_pack(unsigned char r[32], const ge25519 *p) {
+ge25519_pack(unsigned char r[32], const __generic ge25519 *p) {
 	bignum25519 tx, ty, zi;
 	unsigned char parity[32];
 	curve25519_recip(zi, p->z);


### PR DESCRIPTION
Per the comment in #52 this fixes it to run on a newer nvidia driver (545.29.06 with RTX 4090 , on linux - at time of writing).