### PR TITLE
Increase stack size to 8MB

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -125,6 +125,8 @@ fn check_solution(params: &ThreadParams, key_material: [u8; 32]) -> bool {
 }
 
 fn main() {
+    const STACK_SIZE: usize = 8 * 1024 * 1024; // 8 MB
+    std::thread::Builder::new().stack_size(STACK_SIZE).spawn(|| {
     let args = clap::App::new("nano-vanity")
         .version(env!("CARGO_PKG_VERSION"))
         .author("Lee Bousfield <ljbousfield@gmail.com>")
@@ -467,4 +469,5 @@ fn main() {
     }
     eprintln!("No computation devices specified");
     process::exit(1);
+    }).expect("Failed to run main thread").join().expect("Failed to join main thread");
 }


### PR DESCRIPTION
When I start the application on Windows with the --gpu flag, it crashes at line 48 in gpu_impl.rs with the following error message: thread 'main' has overflowed its stack.

The problem no longer occurs when the stack size is increased. It's strange that the default stack size (2MB ?) is exceeded at all. Unfortunately, I am not very good at debugging Rust applications and this fix is probably not very clean, but nevertheless, I wanted to share what I have in case others have the same problem.