### PR TITLE
Fix: Enable apple feature by default for OpenCL builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "BSD-2-Clause"
 
 [features]
 gpu = ["ocl"]
-default = ["gpu"]
+default = ["gpu", "apple"]
 apple = []
 
 [dependencies]


### PR DESCRIPTION
This commit enables the 'apple' feature by default in Cargo.toml, which ensures the correct OpenCL namespace qualifier (__private) is used during compilation on macOS. This resolves the build error encountered on Apple Silicon Macs and improves compatibility.